### PR TITLE
docs: add -i options for sed considering os

### DIFF
--- a/docs/Tutorials/localnet/README.md
+++ b/docs/Tutorials/localnet/README.md
@@ -38,21 +38,28 @@ $BINARY add-genesis-account $($BINARY keys show user2 --keyring-backend test -a)
 $BINARY gentx val1 100000000stake --chain-id $CHAIN_ID --keyring-backend test
 $BINARY collect-gentxs
 
-# Check OS for sed -i option value
-export SED_I=""
-if [[ "$OSTYPE" == "darwin"* ]]; then 
-    export SED_I="''"
-fi 
+# Check platform
+platform='unknown'
+unamestr=`uname`
+if [ "$unamestr" = 'Linux' ]; then
+   platform='linux'
+fi
 
-# Modify app.toml
-sed -i $SED_I 's/enable = false/enable = true/g' $HOME_BUDGETAPP/config/app.toml
-sed -i $SED_I 's/swagger = false/swagger = true/g' $HOME_BUDGETAPP/config/app.toml
-
-# Modify parameters for the governance proposal
-sed -i $SED_I 's%"amount": "10000000"%"amount": "1"%g' $HOME_BUDGETAPP/config/genesis.json
-sed -i $SED_I 's%"quorum": "0.334000000000000000",%"quorum": "0.000000000000000001",%g' $HOME_BUDGETAPP/config/genesis.json
-sed -i $SED_I 's%"threshold": "0.500000000000000000",%"threshold": "0.000000000000000001",%g' $HOME_BUDGETAPP/config/genesis.json
-sed -i $SED_I 's%"voting_period": "172800s"%"voting_period": "30s"%g' $HOME_BUDGETAPP/config/genesis.json
+if [ $platform = 'linux' ]; then
+	sed -i 's/enable = false/enable = true/g' $HOME_BUDGETAPP/config/app.toml
+	sed -i 's/swagger = false/swagger = true/g' $HOME_BUDGETAPP/config/app.toml
+	sed -i 's%"amount": "10000000"%"amount": "1"%g' $HOME_BUDGETAPP/config/genesis.json
+	sed -i 's%"quorum": "0.334000000000000000",%"quorum": "0.000000000000000001",%g' $HOME_BUDGETAPP/config/genesis.json
+	sed -i 's%"threshold": "0.500000000000000000",%"threshold": "0.000000000000000001",%g' $HOME_BUDGETAPP/config/genesis.json
+	sed -i 's%"voting_period": "172800s"%"voting_period": "30s"%g' $HOME_BUDGETAPP/config/genesis.json
+else
+	sed -i '' 's/enable = false/enable = true/g' $HOME_BUDGETAPP/config/app.toml
+	sed -i '' 's/swagger = false/swagger = true/g' $HOME_BUDGETAPP/config/app.toml
+	sed -i '' 's%"amount": "10000000"%"amount": "1"%g' $HOME_BUDGETAPP/config/genesis.json
+	sed -i '' 's%"quorum": "0.334000000000000000",%"quorum": "0.000000000000000001",%g' $HOME_BUDGETAPP/config/genesis.json
+	sed -i '' 's%"threshold": "0.500000000000000000",%"threshold": "0.000000000000000001",%g' $HOME_BUDGETAPP/config/genesis.json
+	sed -i '' 's%"voting_period": "172800s"%"voting_period": "30s"%g' $HOME_BUDGETAPP/config/genesis.json
+fi
 
 # Start
 $BINARY start

--- a/docs/Tutorials/localnet/README.md
+++ b/docs/Tutorials/localnet/README.md
@@ -38,15 +38,21 @@ $BINARY add-genesis-account $($BINARY keys show user2 --keyring-backend test -a)
 $BINARY gentx val1 100000000stake --chain-id $CHAIN_ID --keyring-backend test
 $BINARY collect-gentxs
 
+# Check OS for sed -i option value
+export SED_I=""
+if [[ "$OSTYPE" == "darwin"* ]]; then 
+    export SED_I="''"
+fi 
+
 # Modify app.toml
-sed -i '' 's/enable = false/enable = true/g' $HOME_BUDGETAPP/config/app.toml
-sed -i '' 's/swagger = false/swagger = true/g' $HOME_BUDGETAPP/config/app.toml
+sed -i $SED_I 's/enable = false/enable = true/g' $HOME_BUDGETAPP/config/app.toml
+sed -i $SED_I 's/swagger = false/swagger = true/g' $HOME_BUDGETAPP/config/app.toml
 
 # Modify parameters for the governance proposal
-sed -i '' 's%"amount": "10000000"%"amount": "1"%g' $HOME_BUDGETAPP/config/genesis.json
-sed -i '' 's%"quorum": "0.334000000000000000",%"quorum": "0.000000000000000001",%g' $HOME_BUDGETAPP/config/genesis.json
-sed -i '' 's%"threshold": "0.500000000000000000",%"threshold": "0.000000000000000001",%g' $HOME_BUDGETAPP/config/genesis.json
-sed -i '' 's%"voting_period": "172800s"%"voting_period": "30s"%g' $HOME_BUDGETAPP/config/genesis.json
+sed -i $SED_I 's%"amount": "10000000"%"amount": "1"%g' $HOME_BUDGETAPP/config/genesis.json
+sed -i $SED_I 's%"quorum": "0.334000000000000000",%"quorum": "0.000000000000000001",%g' $HOME_BUDGETAPP/config/genesis.json
+sed -i $SED_I 's%"threshold": "0.500000000000000000",%"threshold": "0.000000000000000001",%g' $HOME_BUDGETAPP/config/genesis.json
+sed -i $SED_I 's%"voting_period": "172800s"%"voting_period": "30s"%g' $HOME_BUDGETAPP/config/genesis.json
 
 # Start
 $BINARY start

--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -40,19 +40,29 @@ echo "Creating and collecting gentx..."
 $BINARY gentx validator 1000000000stake --home $CHAIN_DIR/$CHAIN_ID --chain-id $CHAIN_ID --keyring-backend test
 $BINARY collect-gentxs --home $CHAIN_DIR/$CHAIN_ID
 
-# Check OS for sed -i option value
-export SED_I=""
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    export SED_I="''"
+# Check platform
+platform='unknown'
+unamestr=`uname`
+if [ "$unamestr" = 'Linux' ]; then
+   platform='linux'
 fi
 
 echo "Change settings in config.toml file..."
-sed -i $SED_I 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:'"$RPC_PORT"'"#g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
-sed -i $SED_I 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
-sed -i $SED_I 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
-sed -i $SED_I 's/index_all_keys = false/index_all_keys = true/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
-sed -i $SED_I 's/enable = false/enable = true/g' $CHAIN_DIR/$CHAIN_ID/config/app.toml
-sed -i $SED_I 's/swagger = false/swagger = true/g' $CHAIN_DIR/$CHAIN_ID/config/app.toml
+if [ $platform = 'linux' ]; then
+	sed -i 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:'"$RPC_PORT"'"#g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
+	sed -i 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
+	sed -i 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
+	sed -i 's/index_all_keys = false/index_all_keys = true/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
+	sed -i 's/enable = false/enable = true/g' $CHAIN_DIR/$CHAIN_ID/config/app.toml
+	sed -i 's/swagger = false/swagger = true/g' $CHAIN_DIR/$CHAIN_ID/config/app.toml
+else
+	sed -i '' 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:'"$RPC_PORT"'"#g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
+	sed -i '' 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
+	sed -i '' 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
+	sed -i '' 's/index_all_keys = false/index_all_keys = true/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
+	sed -i '' 's/enable = false/enable = true/g' $CHAIN_DIR/$CHAIN_ID/config/app.toml
+	sed -i '' 's/swagger = false/swagger = true/g' $CHAIN_DIR/$CHAIN_ID/config/app.toml
+fi
 
 echo "Starting $CHAIN_ID in $CHAIN_DIR..."
 echo "Log file is located at $CHAIN_DIR/$CHAIN_ID.log"

--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -40,13 +40,19 @@ echo "Creating and collecting gentx..."
 $BINARY gentx validator 1000000000stake --home $CHAIN_DIR/$CHAIN_ID --chain-id $CHAIN_ID --keyring-backend test
 $BINARY collect-gentxs --home $CHAIN_DIR/$CHAIN_ID
 
+# Check OS for sed -i option value
+export SED_I=""
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    export SED_I="''"
+fi
+
 echo "Change settings in config.toml file..."
-sed -i '' 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:'"$RPC_PORT"'"#g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
-sed -i '' 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
-sed -i '' 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
-sed -i '' 's/index_all_keys = false/index_all_keys = true/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
-sed -i '' 's/enable = false/enable = true/g' $CHAIN_DIR/$CHAIN_ID/config/app.toml
-sed -i '' 's/swagger = false/swagger = true/g' $CHAIN_DIR/$CHAIN_ID/config/app.toml
+sed -i $SED_I 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:'"$RPC_PORT"'"#g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
+sed -i $SED_I 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
+sed -i $SED_I 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
+sed -i $SED_I 's/index_all_keys = false/index_all_keys = true/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
+sed -i $SED_I 's/enable = false/enable = true/g' $CHAIN_DIR/$CHAIN_ID/config/app.toml
+sed -i $SED_I 's/swagger = false/swagger = true/g' $CHAIN_DIR/$CHAIN_ID/config/app.toml
 
 echo "Starting $CHAIN_ID in $CHAIN_DIR..."
 echo "Log file is located at $CHAIN_DIR/$CHAIN_ID.log"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Uses FreeBSD sed command (which is default for MacOS) but I have installed gnu `sed` command (which is default for linux distros) and due to this reason the sed commands from the script can't be work

so need to add simple os checking and using different `-i` options for each os

## References

- https://github.com/tendermint/farming/pull/184

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Appropriate labels applied
- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
